### PR TITLE
Make the render work with older f#

### DIFF
--- a/src/Facil.Generator/Render.fs
+++ b/src/Facil.Generator/Render.fs
@@ -366,7 +366,7 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
         | None ->
             "member this.ExecuteAsync(?cancellationToken) ="
             yield! indent [
-              $"executeNonQueryAsync connStr conn this.configureConn (configureCmd this.userConfigureCmd) [] (defaultArg cancellationToken CancellationToken.None)"
+              $"GeneratedCodeUtils.executeNonQueryAsync connStr conn this.configureConn (configureCmd this.userConfigureCmd) [] (defaultArg cancellationToken CancellationToken.None)"
               if wrapResult then "|> Task.map wrapResultWithOutParams"
             ]
             ""
@@ -374,14 +374,14 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
             ""
             "member this.Execute() ="
             yield! indent [
-              $"executeNonQuery connStr conn this.configureConn (configureCmd this.userConfigureCmd) []"
+              $"GeneratedCodeUtils.executeNonQuery connStr conn this.configureConn (configureCmd this.userConfigureCmd) []"
               if wrapResult then "|> wrapResultWithOutParams"
             ]
 
         | Some _ ->
             "member this.ExecuteAsync(?cancellationToken) ="
             yield! indent [
-              $"executeQueryEagerAsync connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem [] (defaultArg cancellationToken CancellationToken.None)"
+              $"GeneratedCodeUtils.executeQueryEagerAsync connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem [] (defaultArg cancellationToken CancellationToken.None)"
               if wrapResult then "|> Task.map wrapResultWithOutParams"
             ]
             ""
@@ -389,7 +389,7 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
             ""
             "member this.ExecuteAsyncWithSyncRead(?cancellationToken) ="
             yield! indent [
-              $"executeQueryEagerAsyncWithSyncRead connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem [] (defaultArg cancellationToken CancellationToken.None)"
+              $"GeneratedCodeUtils.executeQueryEagerAsyncWithSyncRead connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem [] (defaultArg cancellationToken CancellationToken.None)"
               if wrapResult then "|> Task.map wrapResultWithOutParams"
             ]
             ""
@@ -397,7 +397,7 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
             ""
             "member this.Execute() ="
             yield! indent [
-              $"executeQueryEager connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem []"
+              $"GeneratedCodeUtils.executeQueryEager connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem []"
               if wrapResult then "|> wrapResultWithOutParams"
             ]
             ""
@@ -405,24 +405,24 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
             ""
             "member this.LazyExecuteAsync(?cancellationToken) ="
             yield! indent [
-              $"executeQueryLazyAsync connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem [] (defaultArg cancellationToken CancellationToken.None)"
+              $"GeneratedCodeUtils.executeQueryLazyAsync connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem [] (defaultArg cancellationToken CancellationToken.None)"
             ]
             ""
             "member this.LazyExecuteAsyncWithSyncRead(?cancellationToken) ="
             yield! indent [
-              $"executeQueryLazyAsyncWithSyncRead connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem [] (defaultArg cancellationToken CancellationToken.None)"
+              $"GeneratedCodeUtils.executeQueryLazyAsyncWithSyncRead connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem [] (defaultArg cancellationToken CancellationToken.None)"
             ]
             ""
             "#endif"
             ""
             "member this.LazyExecute() ="
             yield! indent [
-              $"executeQueryLazy connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem []"
+              $"GeneratedCodeUtils.executeQueryLazy connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem []"
             ]
             ""
             "member this.ExecuteSingleAsync(?cancellationToken) ="
             yield! indent [
-              $"""executeQuerySingleAsync{if rule.VoptionOut then "Voption" else ""} connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem [] (defaultArg cancellationToken CancellationToken.None)"""
+              $"""GeneratedCodeUtils.executeQuerySingleAsync{if rule.VoptionOut then "Voption" else ""} connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem [] (defaultArg cancellationToken CancellationToken.None)"""
               if wrapResult then "|> Task.map wrapResultWithOutParams"
             ]
             ""
@@ -430,7 +430,7 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
             ""
             "member this.ExecuteSingle() ="
             yield! indent [
-              $"""executeQuerySingle{if rule.VoptionOut then "Voption" else ""} connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem []"""
+              $"""GeneratedCodeUtils.executeQuerySingle{if rule.VoptionOut then "Voption" else ""} connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem []"""
               if wrapResult then "|> wrapResultWithOutParams"
             ]
       ]
@@ -516,83 +516,83 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
 
         match resultSet with
         | None ->
-            "member _.ExecuteAsync(?cancellationToken) ="
+            "member this.ExecuteAsync(?cancellationToken) ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
-              "executeNonQueryAsync connStr conn configureConn (configureCmd sqlParams) tempTableData (defaultArg cancellationToken CancellationToken.None)"
+              "GeneratedCodeUtils.executeNonQueryAsync connStr conn configureConn (configureCmd sqlParams) tempTableData (defaultArg cancellationToken CancellationToken.None)"
               if wrapResult then "|> Task.map (wrapResultWithOutParams sqlParams)"
             ]
             ""
             yield! asyncOverTaskFor "ExecuteAsync" "AsyncExecute"
             ""
-            "member _.Execute() ="
+            "member this.Execute() ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
-              "executeNonQuery connStr conn configureConn (configureCmd sqlParams) tempTableData"
+              "GeneratedCodeUtils.executeNonQuery connStr conn configureConn (configureCmd sqlParams) tempTableData"
               if wrapResult then "|> wrapResultWithOutParams sqlParams"
             ]
 
         | Some _ ->
-            "member _.ExecuteAsync(?cancellationToken) ="
+            "member this.ExecuteAsync(?cancellationToken) ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
-              "executeQueryEagerAsync connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"
+              "GeneratedCodeUtils.executeQueryEagerAsync connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"
               if wrapResult then "|> Task.map (wrapResultWithOutParams sqlParams)"
             ]
             ""
             yield! asyncOverTaskFor "ExecuteAsync" "AsyncExecute"
             ""
-            "member _.ExecuteAsyncWithSyncRead(?cancellationToken) ="
+            "member this.ExecuteAsyncWithSyncRead(?cancellationToken) ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
-              "executeQueryEagerAsyncWithSyncRead connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"
+              "GeneratedCodeUtils.executeQueryEagerAsyncWithSyncRead connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"
               if wrapResult then "|> Task.map (wrapResultWithOutParams sqlParams)"
             ]
             ""
             yield! asyncOverTaskFor "ExecuteAsyncWithSyncRead" "AsyncExecuteWithSyncRead"
             ""
-            "member _.Execute() ="
+            "member this.Execute() ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
-              "executeQueryEager connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData"
+              "GeneratedCodeUtils.executeQueryEager connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData"
               if wrapResult then "|> wrapResultWithOutParams sqlParams"
             ]
             ""
             "#if (!NETFRAMEWORK && !NET461 && !NET462 && !NET47 && !NET471 && !NET472 && !NET48 && !NETSTANDARD2_0 && !NETCOREAPP2_0 && !NETCOREAPP2_1 && !NETCOREAPP2_2)"
             ""
-            "member _.LazyExecuteAsync(?cancellationToken) ="
+            "member this.LazyExecuteAsync(?cancellationToken) ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
-              "executeQueryLazyAsync connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"
+              "GeneratedCodeUtils.executeQueryLazyAsync connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"
             ]
             ""
-            "member _.LazyExecuteAsyncWithSyncRead(?cancellationToken) ="
+            "member this.LazyExecuteAsyncWithSyncRead(?cancellationToken) ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
-              "executeQueryLazyAsyncWithSyncRead connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"
+              "GeneratedCodeUtils.executeQueryLazyAsyncWithSyncRead connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"
             ]
             ""
             "#endif"
             ""
-            "member _.LazyExecute() ="
+            "member this.LazyExecute() ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
-              "executeQueryLazy connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData"
+              "GeneratedCodeUtils.executeQueryLazy connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData"
             ]
             ""
-            "member _.ExecuteSingleAsync(?cancellationToken) ="
+            "member this.ExecuteSingleAsync(?cancellationToken) ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
-              $"""executeQuerySingleAsync{if rule.VoptionOut then "Voption" else ""} connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"""
+              $"""GeneratedCodeUtils.executeQuerySingleAsync{if rule.VoptionOut then "Voption" else ""} connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"""
               if wrapResult then "|> Task.map (wrapResultWithOutParams sqlParams)"
             ]
             ""
             yield! asyncOverTaskFor "ExecuteSingleAsync" "AsyncExecuteSingle"
             ""
-            "member _.ExecuteSingle() ="
+            "member this.ExecuteSingle() ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
-              $"""executeQuerySingle{if rule.VoptionOut then "Voption" else ""} connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData"""
+              $"""GeneratedCodeUtils.executeQuerySingle{if rule.VoptionOut then "Voption" else ""} connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData"""
               if wrapResult then "|> wrapResultWithOutParams sqlParams"
             ]
       ]
@@ -610,7 +610,7 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
           yield! indent [
             ""
             "[<EditorBrowsable(EditorBrowsableState.Never)>]"
-            "member _.Fields = fields"
+            "member this.Fields = fields"
             ""
             "static member create"
             yield! indent [
@@ -985,8 +985,8 @@ let renderDocument (cfg: RuleSet) hash (everything: Everything) =
     "open Microsoft.Data.SqlClient"
     "open Microsoft.Data.SqlClient.Server"
     "open Facil.Runtime.CSharp"
+    "open Facil.Runtime"
     "open Facil.Runtime.GeneratedCodeUtils"
-    ""
     ""
     match cfg.Prelude with
     | None -> ()

--- a/src/Facil.Generator/Render.fs
+++ b/src/Facil.Generator/Render.fs
@@ -516,7 +516,7 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
 
         match resultSet with
         | None ->
-            "member _.ExecuteAsync(?cancellationToken) ="
+            "member __.ExecuteAsync(?cancellationToken) ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
               "executeNonQueryAsync connStr conn configureConn (configureCmd sqlParams) tempTableData (defaultArg cancellationToken CancellationToken.None)"
@@ -525,7 +525,7 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
             ""
             yield! asyncOverTaskFor "ExecuteAsync" "AsyncExecute"
             ""
-            "member _.Execute() ="
+            "member __.Execute() ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
               "executeNonQuery connStr conn configureConn (configureCmd sqlParams) tempTableData"
@@ -533,7 +533,7 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
             ]
 
         | Some _ ->
-            "member _.ExecuteAsync(?cancellationToken) ="
+            "member __.ExecuteAsync(?cancellationToken) ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
               "executeQueryEagerAsync connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"
@@ -542,7 +542,7 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
             ""
             yield! asyncOverTaskFor "ExecuteAsync" "AsyncExecute"
             ""
-            "member _.ExecuteAsyncWithSyncRead(?cancellationToken) ="
+            "member __.ExecuteAsyncWithSyncRead(?cancellationToken) ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
               "executeQueryEagerAsyncWithSyncRead connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"
@@ -551,7 +551,7 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
             ""
             yield! asyncOverTaskFor "ExecuteAsyncWithSyncRead" "AsyncExecuteWithSyncRead"
             ""
-            "member _.Execute() ="
+            "member __.Execute() ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
               "executeQueryEager connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData"
@@ -560,13 +560,13 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
             ""
             "#if (!NETFRAMEWORK && !NET461 && !NET462 && !NET47 && !NET471 && !NET472 && !NET48 && !NETSTANDARD2_0 && !NETCOREAPP2_0 && !NETCOREAPP2_1 && !NETCOREAPP2_2)"
             ""
-            "member _.LazyExecuteAsync(?cancellationToken) ="
+            "member __.LazyExecuteAsync(?cancellationToken) ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
               "executeQueryLazyAsync connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"
             ]
             ""
-            "member _.LazyExecuteAsyncWithSyncRead(?cancellationToken) ="
+            "member __.LazyExecuteAsyncWithSyncRead(?cancellationToken) ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
               "executeQueryLazyAsyncWithSyncRead connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"
@@ -574,13 +574,13 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
             ""
             "#endif"
             ""
-            "member _.LazyExecute() ="
+            "member __.LazyExecute() ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
               "executeQueryLazy connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData"
             ]
             ""
-            "member _.ExecuteSingleAsync(?cancellationToken) ="
+            "member __.ExecuteSingleAsync(?cancellationToken) ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
               $"""executeQuerySingleAsync{if rule.VoptionOut then "Voption" else ""} connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"""
@@ -589,7 +589,7 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
             ""
             yield! asyncOverTaskFor "ExecuteSingleAsync" "AsyncExecuteSingle"
             ""
-            "member _.ExecuteSingle() ="
+            "member __.ExecuteSingle() ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
               $"""executeQuerySingle{if rule.VoptionOut then "Voption" else ""} connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData"""
@@ -610,7 +610,7 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
           yield! indent [
             ""
             "[<EditorBrowsable(EditorBrowsableState.Never)>]"
-            "member _.Fields = fields"
+            "member __.Fields = fields"
             ""
             "static member create"
             yield! indent [

--- a/src/Facil.Generator/Render.fs
+++ b/src/Facil.Generator/Render.fs
@@ -366,7 +366,7 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
         | None ->
             "member this.ExecuteAsync(?cancellationToken) ="
             yield! indent [
-              $"GeneratedCodeUtils.executeNonQueryAsync connStr conn this.configureConn (configureCmd this.userConfigureCmd) [] (defaultArg cancellationToken CancellationToken.None)"
+              $"executeNonQueryAsync connStr conn this.configureConn (configureCmd this.userConfigureCmd) [] (defaultArg cancellationToken CancellationToken.None)"
               if wrapResult then "|> Task.map wrapResultWithOutParams"
             ]
             ""
@@ -374,14 +374,14 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
             ""
             "member this.Execute() ="
             yield! indent [
-              $"GeneratedCodeUtils.executeNonQuery connStr conn this.configureConn (configureCmd this.userConfigureCmd) []"
+              $"executeNonQuery connStr conn this.configureConn (configureCmd this.userConfigureCmd) []"
               if wrapResult then "|> wrapResultWithOutParams"
             ]
 
         | Some _ ->
             "member this.ExecuteAsync(?cancellationToken) ="
             yield! indent [
-              $"GeneratedCodeUtils.executeQueryEagerAsync connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem [] (defaultArg cancellationToken CancellationToken.None)"
+              $"executeQueryEagerAsync connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem [] (defaultArg cancellationToken CancellationToken.None)"
               if wrapResult then "|> Task.map wrapResultWithOutParams"
             ]
             ""
@@ -389,7 +389,7 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
             ""
             "member this.ExecuteAsyncWithSyncRead(?cancellationToken) ="
             yield! indent [
-              $"GeneratedCodeUtils.executeQueryEagerAsyncWithSyncRead connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem [] (defaultArg cancellationToken CancellationToken.None)"
+              $"executeQueryEagerAsyncWithSyncRead connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem [] (defaultArg cancellationToken CancellationToken.None)"
               if wrapResult then "|> Task.map wrapResultWithOutParams"
             ]
             ""
@@ -397,7 +397,7 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
             ""
             "member this.Execute() ="
             yield! indent [
-              $"GeneratedCodeUtils.executeQueryEager connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem []"
+              $"executeQueryEager connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem []"
               if wrapResult then "|> wrapResultWithOutParams"
             ]
             ""
@@ -405,24 +405,24 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
             ""
             "member this.LazyExecuteAsync(?cancellationToken) ="
             yield! indent [
-              $"GeneratedCodeUtils.executeQueryLazyAsync connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem [] (defaultArg cancellationToken CancellationToken.None)"
+              $"executeQueryLazyAsync connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem [] (defaultArg cancellationToken CancellationToken.None)"
             ]
             ""
             "member this.LazyExecuteAsyncWithSyncRead(?cancellationToken) ="
             yield! indent [
-              $"GeneratedCodeUtils.executeQueryLazyAsyncWithSyncRead connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem [] (defaultArg cancellationToken CancellationToken.None)"
+              $"executeQueryLazyAsyncWithSyncRead connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem [] (defaultArg cancellationToken CancellationToken.None)"
             ]
             ""
             "#endif"
             ""
             "member this.LazyExecute() ="
             yield! indent [
-              $"GeneratedCodeUtils.executeQueryLazy connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem []"
+              $"executeQueryLazy connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem []"
             ]
             ""
             "member this.ExecuteSingleAsync(?cancellationToken) ="
             yield! indent [
-              $"""GeneratedCodeUtils.executeQuerySingleAsync{if rule.VoptionOut then "Voption" else ""} connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem [] (defaultArg cancellationToken CancellationToken.None)"""
+              $"""executeQuerySingleAsync{if rule.VoptionOut then "Voption" else ""} connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem [] (defaultArg cancellationToken CancellationToken.None)"""
               if wrapResult then "|> Task.map wrapResultWithOutParams"
             ]
             ""
@@ -430,7 +430,7 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
             ""
             "member this.ExecuteSingle() ="
             yield! indent [
-              $"""GeneratedCodeUtils.executeQuerySingle{if rule.VoptionOut then "Voption" else ""} connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem []"""
+              $"""executeQuerySingle{if rule.VoptionOut then "Voption" else ""} connStr conn this.configureConn (configureCmd this.userConfigureCmd) initOrdinals getItem []"""
               if wrapResult then "|> wrapResultWithOutParams"
             ]
       ]
@@ -516,83 +516,83 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
 
         match resultSet with
         | None ->
-            "member this.ExecuteAsync(?cancellationToken) ="
+            "member _.ExecuteAsync(?cancellationToken) ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
-              "GeneratedCodeUtils.executeNonQueryAsync connStr conn configureConn (configureCmd sqlParams) tempTableData (defaultArg cancellationToken CancellationToken.None)"
+              "executeNonQueryAsync connStr conn configureConn (configureCmd sqlParams) tempTableData (defaultArg cancellationToken CancellationToken.None)"
               if wrapResult then "|> Task.map (wrapResultWithOutParams sqlParams)"
             ]
             ""
             yield! asyncOverTaskFor "ExecuteAsync" "AsyncExecute"
             ""
-            "member this.Execute() ="
+            "member _.Execute() ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
-              "GeneratedCodeUtils.executeNonQuery connStr conn configureConn (configureCmd sqlParams) tempTableData"
+              "executeNonQuery connStr conn configureConn (configureCmd sqlParams) tempTableData"
               if wrapResult then "|> wrapResultWithOutParams sqlParams"
             ]
 
         | Some _ ->
-            "member this.ExecuteAsync(?cancellationToken) ="
+            "member _.ExecuteAsync(?cancellationToken) ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
-              "GeneratedCodeUtils.executeQueryEagerAsync connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"
+              "executeQueryEagerAsync connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"
               if wrapResult then "|> Task.map (wrapResultWithOutParams sqlParams)"
             ]
             ""
             yield! asyncOverTaskFor "ExecuteAsync" "AsyncExecute"
             ""
-            "member this.ExecuteAsyncWithSyncRead(?cancellationToken) ="
+            "member _.ExecuteAsyncWithSyncRead(?cancellationToken) ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
-              "GeneratedCodeUtils.executeQueryEagerAsyncWithSyncRead connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"
+              "executeQueryEagerAsyncWithSyncRead connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"
               if wrapResult then "|> Task.map (wrapResultWithOutParams sqlParams)"
             ]
             ""
             yield! asyncOverTaskFor "ExecuteAsyncWithSyncRead" "AsyncExecuteWithSyncRead"
             ""
-            "member this.Execute() ="
+            "member _.Execute() ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
-              "GeneratedCodeUtils.executeQueryEager connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData"
+              "executeQueryEager connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData"
               if wrapResult then "|> wrapResultWithOutParams sqlParams"
             ]
             ""
             "#if (!NETFRAMEWORK && !NET461 && !NET462 && !NET47 && !NET471 && !NET472 && !NET48 && !NETSTANDARD2_0 && !NETCOREAPP2_0 && !NETCOREAPP2_1 && !NETCOREAPP2_2)"
             ""
-            "member this.LazyExecuteAsync(?cancellationToken) ="
+            "member _.LazyExecuteAsync(?cancellationToken) ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
-              "GeneratedCodeUtils.executeQueryLazyAsync connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"
+              "executeQueryLazyAsync connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"
             ]
             ""
-            "member this.LazyExecuteAsyncWithSyncRead(?cancellationToken) ="
+            "member _.LazyExecuteAsyncWithSyncRead(?cancellationToken) ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
-              "GeneratedCodeUtils.executeQueryLazyAsyncWithSyncRead connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"
+              "executeQueryLazyAsyncWithSyncRead connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"
             ]
             ""
             "#endif"
             ""
-            "member this.LazyExecute() ="
+            "member _.LazyExecute() ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
-              "GeneratedCodeUtils.executeQueryLazy connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData"
+              "executeQueryLazy connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData"
             ]
             ""
-            "member this.ExecuteSingleAsync(?cancellationToken) ="
+            "member _.ExecuteSingleAsync(?cancellationToken) ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
-              $"""GeneratedCodeUtils.executeQuerySingleAsync{if rule.VoptionOut then "Voption" else ""} connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"""
+              $"""executeQuerySingleAsync{if rule.VoptionOut then "Voption" else ""} connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData (defaultArg cancellationToken CancellationToken.None)"""
               if wrapResult then "|> Task.map (wrapResultWithOutParams sqlParams)"
             ]
             ""
             yield! asyncOverTaskFor "ExecuteSingleAsync" "AsyncExecuteSingle"
             ""
-            "member this.ExecuteSingle() ="
+            "member _.ExecuteSingle() ="
             yield! indent [
               "let sqlParams = getSqlParams ()"
-              $"""GeneratedCodeUtils.executeQuerySingle{if rule.VoptionOut then "Voption" else ""} connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData"""
+              $"""executeQuerySingle{if rule.VoptionOut then "Voption" else ""} connStr conn configureConn (configureCmd sqlParams) initOrdinals getItem tempTableData"""
               if wrapResult then "|> wrapResultWithOutParams sqlParams"
             ]
       ]
@@ -610,7 +610,7 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
           yield! indent [
             ""
             "[<EditorBrowsable(EditorBrowsableState.Never)>]"
-            "member this.Fields = fields"
+            "member _.Fields = fields"
             ""
             "static member create"
             yield! indent [
@@ -985,8 +985,8 @@ let renderDocument (cfg: RuleSet) hash (everything: Everything) =
     "open Microsoft.Data.SqlClient"
     "open Microsoft.Data.SqlClient.Server"
     "open Facil.Runtime.CSharp"
-    "open Facil.Runtime"
     "open Facil.Runtime.GeneratedCodeUtils"
+    ""
     ""
     match cfg.Prelude with
     | None -> ()


### PR DESCRIPTION
When using `FSharp.Compiler.Tools` you do not have access to:

* opening of static classes
* `member _.` - this is throwing an error but I can't find the documentation when this was added - quite hard to search for

 this just add `GeneratedCodeUtils` to the functions and replace `_.` with `this.`