### PR TITLE
Force the compiler to not inline large tables

### DIFF
--- a/src/DbTests/DbGen.fs
+++ b/src/DbTests/DbGen.fs
@@ -1,4 +1,4 @@
-﻿// Edit or remove this or the below line to regenerate on next build
+// Edit or remove this or the below line to regenerate on next build
 // Hash: b6421047e33b298e5e7809d66b623e9a6bbe200b63eb4f83fbd1411740f8ecbd
 
 //////////////////////////////////////////
@@ -12667,6 +12667,7 @@ module Scripts =
       let ``Column598`` = if reader.IsDBNull ``ordinal_Column598`` then None else reader.GetInt32 ``ordinal_Column598`` |> Some
       let ``Column599`` = if reader.IsDBNull ``ordinal_Column599`` then None else reader.GetInt32 ``ordinal_Column599`` |> Some
       let ``Column600`` = if reader.IsDBNull ``ordinal_Column600`` then None else reader.GetInt32 ``ordinal_Column600`` |> Some
+      reader.IsClosed |> ignore // Disable compiler optimization that causes stack overflow at runtime for large records
       {|
         ``Column1`` = ``Column1``
         ``Column2`` = ``Column2``

--- a/src/Facil.Generator/Render.fs
+++ b/src/Facil.Generator/Render.fs
@@ -307,6 +307,9 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
                   $"let ``{c.Name.Value}`` = if reader.IsDBNull ``ordinal_{c.Name.Value}`` then {outOptionNone} else reader.{c.TypeInfo.SqlDataReaderGetMethodName} ``ordinal_{c.Name.Value}`` |> {outOptionSome}"
                 else
                   $"let ``{c.Name.Value}`` = reader.{c.TypeInfo.SqlDataReaderGetMethodName} ``ordinal_{c.Name.Value}``"
+
+              if cols.Length > 100 then // Arbitrary amount for a big record
+                "reader.IsClosed |> ignore // Disable compiler optimization that causes stack overflow at runtime for large records"
             ]
 
             yield! indent [
@@ -495,6 +498,9 @@ let private renderProcOrScript (cfg: RuleSet) (tableDtos: TableDto list) (execut
                   $"let ``{c.Name.Value}`` = if reader.IsDBNull ``ordinal_{c.Name.Value}`` then {outOptionNone} else reader.{c.TypeInfo.SqlDataReaderGetMethodName} ``ordinal_{c.Name.Value}`` |> {outOptionSome}"
                 else
                   $"let ``{c.Name.Value}`` = reader.{c.TypeInfo.SqlDataReaderGetMethodName} ``ordinal_{c.Name.Value}``"
+
+              if cols.Length > 100 then // Arbitrary amount for a big record
+                "reader.IsClosed |> ignore // Disable compiler optimization that causes stack overflow at runtime for large records"
             ]
 
             yield! indent [


### PR DESCRIPTION
2nd fix for https://github.com/cmeeren/Facil/issues/9

Build and tested local via:

```
dotnet build -c Release src\Facil.Generator
dotnet build -c Release src\Facil.Package
dotnet pack -c Release src\Facil.Package
dotnet build -c Release src\DbTests
dotnet src\DbTests\bin\Release\net5.0\DbTests.dll --fail-on-focused-tests
```

![image](https://user-images.githubusercontent.com/1804141/108088347-41f2a080-7070-11eb-8fa1-783125ccf046.png)

