### PR TITLE
Added GeneratedCode attribute to the generated file

### DIFF
--- a/src/DbTests.DbGen/DbGen.fs
+++ b/src/DbTests.DbGen/DbGen.fs
@@ -9,6 +9,7 @@
 //
 //////////////////////////////////////////
 
+[<System.CodeDom.Compiler.GeneratedCode("Facil", "2.14.1+2a600a8cf8db0bf66e84d0920d1939c4368efc35")>]
 module DbGen
 
 #nowarn "49"

--- a/src/Facil.Generator/Render.fs
+++ b/src/Facil.Generator/Render.fs
@@ -1387,6 +1387,7 @@ let renderDocument (cfg: RuleSet) hash (everything: Everything) =
         "//"
         "//////////////////////////////////////////"
         ""
+        $"[<System.CodeDom.Compiler.GeneratedCode(\"Facil\", \"{version}\")>]"
         cfg.NamespaceOrModuleDeclaration
         ""
         "#nowarn \"49\""


### PR DESCRIPTION
Generally, it's a good practice to mark GeneratedCode with this attribute so that users' tools (such as code analysers) know to ignore it.
